### PR TITLE
fix: isort error in __main__.py

### DIFF
--- a/src/dgp_cnpq_lib/__main__.py
+++ b/src/dgp_cnpq_lib/__main__.py
@@ -1,8 +1,8 @@
+import argparse
 import json
+import logging
 import re
 import sys
-import argparse
-import logging
 
 from .core import CnpqCrawler
 


### PR DESCRIPTION
Fix import sorting error in `src/dgp_cnpq_lib/__main__.py`.

**Changes**:
- Applied `isort` formatting to `src/dgp_cnpq_lib/__main__.py`.

Closes #27
