### PR TITLE
docs: add GitHub Action monitoring standards

### DIFF
--- a/.agent/workflows/agile-standards.md
+++ b/.agent/workflows/agile-standards.md
@@ -85,6 +85,7 @@ Maintain the following artifacts throughout the lifecycle:
 ## 8. Merge Standards
 - [ ] **Conflict Free**: PR can be merged if there are no conflicts.
 - [ ] **Automation**: If the CI pipeline (`.github/workflows/ci.yml`) passes, the PR MUST be merged and related issues closed automatically. **MANDATORY AND NON-NEGOTIABLE**.
+- [ ] **Monitoring**: Any GitHub Action failure MUST result in the immediate creation of a Bug Issue to track the fix. **MANDATORY**.
 - [ ] **Cleanup**: 
     - [ ] **Remote**: Delete the feature/bugfix branch from GitHub immediately after the PR is merged.
     - [ ] **Local**: Delete the local branch to keep the workspace clean.
@@ -94,6 +95,7 @@ Maintain the following artifacts throughout the lifecycle:
 - [ ] **Verification**:
     - [ ] Test suite passing.
     - [ ] Linting checks passing.
+    - [ ] **CI Verification**: Confirm all GitHub Actions pass on the final commit. **MANDATORY**.
     - [ ] **OO Compliance**: Verified usage of Classes and Encapsulation.
 - [ ] **Documentation**:
     - [ ] Update Google-style docstrings.


### PR DESCRIPTION
Update Agile Standards with mandatory CI/CD Monitoring.

## Changes
- **Merge Standards**: Added requirement to create a Bug Issue for any GitHub Action failure.
- **Definition of Done**: Added mandatory check to confirm all GitHub Actions pass before task closure.

Closes #32
